### PR TITLE
feat: add lambda authorization for /import endpoint

### DIFF
--- a/authorization-service/.gitignore
+++ b/authorization-service/.gitignore
@@ -1,0 +1,8 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless
+
+.env

--- a/authorization-service/handler.js
+++ b/authorization-service/handler.js
@@ -1,7 +1,6 @@
 "use strict";
 
 module.exports.basicAuthorizer = async (event, context, cb) => {
-
   const validUserName = process.env.USER_ID;
   const validUserPassword = process.env.PASSWORD;
 

--- a/authorization-service/handler.js
+++ b/authorization-service/handler.js
@@ -1,0 +1,57 @@
+"use strict";
+
+module.exports.basicAuthorizer = async (event, context, cb) => {
+
+  const validUserName = process.env.USER_ID;
+  const validUserPassword = process.env.PASSWORD;
+
+  if (event["type"] !== "TOKEN") {
+    return cb("Unauthorized");
+  }
+
+  try {
+    const { authorizationToken, methodArn } = event;
+    const [, encodedCreds] = authorizationToken.split(" ");
+    const [username, password] = Buffer.from(encodedCreds, "base64")
+      .toString()
+      .split(":");
+
+    const effect =
+      validUserName === username && validUserPassword === password
+        ? "Allow"
+        : "Deny";
+
+    const policy = generatePolicy(encodedCreds, methodArn, effect);
+    cb(null, policy);
+  } catch (e) {
+    return cb(`Unauthorized: ${e.message}`);
+  }
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify(
+      {
+        message: "Successfully authorized",
+        input: event,
+      },
+      null,
+      2
+    ),
+  };
+};
+
+function generatePolicy(principalId, resource, effect = "Allow") {
+  return {
+    principalId,
+    policyDocument: {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: effect,
+          Action: "execute-api:Invoke",
+          Resource: resource,
+        },
+      ],
+    },
+  };
+}

--- a/authorization-service/package-lock.json
+++ b/authorization-service/package-lock.json
@@ -1,0 +1,80 @@
+{
+  "name": "authorization-service",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "dev": true
+    },
+    "dotenv-expand": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "serverless-dotenv-plugin": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/serverless-dotenv-plugin/-/serverless-dotenv-plugin-3.9.0.tgz",
+      "integrity": "sha512-T2fso08DSVfBVMUQX4UxjaCzB32IMD0GOTqncuLUek77YMPrJTmJlKOGr5z64Oe/ySZhR7SJZF9Jn0FJCq7cIg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "dotenv": "^8.2.0",
+        "dotenv-expand": "^5.1.0"
+      }
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    }
+  }
+}

--- a/authorization-service/package.json
+++ b/authorization-service/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "authorization-service",
+  "version": "1.0.0",
+  "description": "",
+  "main": "handler.js",
+  "scripts": {
+    "deploy": "sls deploy"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "serverless-dotenv-plugin": "^3.9.0"
+  }
+}

--- a/authorization-service/serverless.yml
+++ b/authorization-service/serverless.yml
@@ -1,0 +1,18 @@
+service: authorization-service
+frameworkVersion: '2'
+
+plugins:
+  - serverless-dotenv-plugin
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+  lambdaHashingVersion: 20201221
+
+  environment:
+    USER_ID: ${env:USER_ID}
+    PASSWORD: ${env:PASSWORD}
+
+functions:
+  basicAuthorizer:
+    handler: handler.basicAuthorizer

--- a/import-service/package-lock.json
+++ b/import-service/package-lock.json
@@ -88,6 +88,12 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
+    "serverless-pseudo-parameters": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/serverless-pseudo-parameters/-/serverless-pseudo-parameters-2.5.0.tgz",
+      "integrity": "sha512-A/O49AR8LL6jlnPSmnOTYgL1KqVgskeRla4sVDeS/r5dHFJlwOU5MgFilc7aaQP8NWAwRJANaIS9oiSE3I+VUA==",
+      "dev": true
+    },
     "url": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",

--- a/import-service/package.json
+++ b/import-service/package.json
@@ -13,5 +13,8 @@
     "aws-sdk": "^2.894.0",
     "csv-parser": "^3.0.0",
     "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "serverless-pseudo-parameters": "^2.5.0"
   }
 }

--- a/import-service/serverless.yml
+++ b/import-service/serverless.yml
@@ -1,6 +1,9 @@
 service: import-service
 frameworkVersion: '2'
 
+plugins:
+  - serverless-pseudo-parameters
+
 provider:
   name: aws
   runtime: nodejs12.x
@@ -40,6 +43,12 @@ functions:
           request:
             querystrings:
               name: true
+          authorizer:
+            name: basicAuthorizer
+            arn: arn:aws:lambda:${self:provider.region}:#{AWS::AccountId}:function:authorization-service-dev-basicAuthorizer
+            resultTtlInSeconds: 0
+            identitySource: method.request.header.Authorization
+            type: token
   importFileParser:
     handler: handler.importFileParser
     events:


### PR DESCRIPTION
- added  authorization-service to the repo with basicAuthorizer lambda in serverless.yaml file
- updated import-service serverless.yaml file with  authorizer configuration for the importProductsFile lambda

Links:
- [FE app](https://d1aozobrzk7at4.cloudfront.net/)
 - [FE PR](https://github.com/kat-ya/nodejs-aws-fe/pull/4)
- [Lambda auth protected endpoint](https://vzv3uqe62c.execute-api.us-east-1.amazonaws.com/dev/import?name=flowers.csv)

